### PR TITLE
Fixed up so that catalog detail page works.

### DIFF
--- a/app.js
+++ b/app.js
@@ -43,11 +43,12 @@ app.get('/search', function(req, res) {
 
 app.get('/catalog/:id', function(req, res) {
   var id = req.params.id;
-  var catalog = catalog.get(id)
-  if (!dataset) {
+  var c = catalog.get(id)
+  if (!c) {
     res.send(404, 'Not Found');
   }
   res.render('catalog.html', {
+      'catalog': c
   });
 });
 

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -163,3 +163,9 @@ footer {
   height: 500px;
 }
 
+
+a.inverted {
+  color: #fff;
+}
+
+dt { margin-top: 10px; }

--- a/templates/_snippets.html
+++ b/templates/_snippets.html
@@ -3,16 +3,20 @@
     <img src="{{catalog.image or
       'http://assets.okfn.org/p/opendatahandbook/img/data-wrench.png'}}"
       alt="{{catalog.title}}" class="logo" />
-    <h3><a href="/{{catalog.id}}">{{catalog.title}}</a></h3>
+    <h3><a href="/catalog/{{catalog.id}}">{{catalog.title}}</a></h3>
     <div class="description">{{catalog.description}}</div>
     <ul class="keywords">
       {% for kw in catalog.tags or [] %}
-      <li>{{kw}}</li>
+        {% if kw %}
+          <li>{{kw}}</li>
+        {% endif %}
       {% endfor %}
     </ul>
     <ul class="groups">
       {% for kw in catalog.group or [] %}
-      <li><a href="/group/{{kw}}">{{kw}}</a></li>
+        {% if kw %}
+          <li><a href="/group/{{kw}}">{{kw}}</a></li>
+        {% endif %}
       {% endfor %}
     </ul>
   </div>

--- a/templates/catalog.html
+++ b/templates/catalog.html
@@ -1,0 +1,54 @@
+{% extends "base.html" %}
+
+{% block title %}
+
+{% endblock %}
+
+{% block content %}
+  <div class="page-header">
+    <h1>
+        <img src="{{catalog.image or
+      'http://assets.okfn.org/p/opendatahandbook/img/data-wrench.png'}}"
+      alt="{{catalog.title}}" class="logo" />
+
+        {{catalog.title}}
+    </h1>
+  </div>
+  <div class="row">
+        <div class="span6">
+            <h2>Description</h2>
+            {{ catalog.description }}
+        </div>
+
+        <div class="span6">
+            <dl>
+                <dt>
+                    URL:
+                </dt>
+                <dd>
+                    <a href="{{ catalog.url }}">{{ catalog.url }}</a>
+                </dd>
+                <dt>
+                    Tags:
+                </dt>
+                <dd>
+                      {% for kw in catalog.tags or [] %}
+                        {% if kw %}
+                            <span class="label label-primary">{{kw}}</span>
+                        {% endif %}
+                      {% endfor %}
+                </dd>
+                <dt>
+                    Groups:
+                </dt>
+                <dd>
+                      {% for kw in catalog.group or [] %}
+                        {% if kw %}
+                          <span class="label label-warning"><a class="inverted" href="/group/{{kw}}">{{kw}}</a></span>
+                        {% endif %}
+                      {% endfor %}
+                </dd>
+            </dl>
+        </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
- Added the missing catalog.html template
  - This is quite minimal, and currently just contains the same
    info as on the summary page, but could be extended to contain
    more useful info (# datasets etc, software/version used)
- Fixed the typo (re-assigning catalog) for the catalog route
- Fixed hiding of keywords/group with no name.
