### PR TITLE
Direct suggestions to Open Knowledge Discussion Forum

### DIFF
--- a/views/about.html
+++ b/views/about.html
@@ -21,13 +21,9 @@ which will be launched over the coming months.
 </p>
 
 <p>
-If you have an idea for something you think we should add, please let
-us know via the form. If you're interested talking to other people interested in open
-government data, you can join the
-<a href="http://lists.okfn.org/mailman/listinfo/open-government">open-government</a>
-list or follow 
-<a href="http://twitter.com/#!/search/%23opendata">#opendata on Twitter</a>.
-</p>        
+If you have an idea for a feature you think we should add, please let us know via the 
+<a href="https://discuss.okfn.org/c/open-knowledge-labs/dataportals">discussion forum</a>.
+</p>
 
 <h2 id="curators-heading">Curators</h2>
 <ul id="curators">


### PR DESCRIPTION
The Open Government Data mailing list is migrating to the Open
Knowledge Discussion Forum. A specific category for DataPortals.org has
been added to the forum.