### PR TITLE
Fixed broken link in catalogs

### DIFF
--- a/data/catalogs.csv
+++ b/data/catalogs.csv
@@ -40,7 +40,7 @@ Linked Open Camera,camera,ctic,http://www.linkedopencamera.it/index.php/i-dati,,
 The City & County of Honolulu’s goal is to provide the public with an unprecedented amount of access to information previously unavailable from prior administrations.  This is part of a national trend in government towards “transparency.”  Can-Do Honolulu will serve the people of Honolulu as an indispensable conduit to their government. ",unitedstates,"Honolulu, Hawaii",,"21.304547,-157.8556764","21.3069444,-157.8583333",active,Other::License Not Specified,2011-07-28T03:29:59.725Z,2012-08-13T13:01:28.532Z,2011-10-21T15:42:01.733Z
 Italian Chamber of Deputies,chamber_of_deputies_it,italy,http://dati.camera.it/it/,Italian Chamber of Deputies,"The history, activities, mechanisms of functioning of the Chamber of Deputies. Available free to reuse. 
 ",italy,Italy,,"42.6384261,12.674297","42.8333333,12.8333333",active,OKD Compliant::Creative Commons Attribution Share-Alike,2012-01-12T15:47:09.809Z,2012-12-08T18:15:46.584Z,2012-12-08T18:15:46.262Z
-datos.gob.cl,chile-government,government,http://www.data.gov.cl/,Gobierno de Chile (Chile government),"Official Chile government open data site.
+datos.gob.cl,chile-government,government,http://datos.gob.cl/,Gobierno de Chile (Chile government),"Official Chile government open data site.
 
 From the beta welcome message:
 


### PR DESCRIPTION
www.data.gov.cl was replaced with datos.gob.cl