### PR TITLE
fix rendering of catalog description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "dataportals",
   "version": "0.1.1",
+  "main": "app.js",
+  "scripts": {
+    "start": "node app.js"
+  },
   "dependencies": {
     "express": "4.16.x",
     "body-parser": "1.18.x",

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -27,7 +27,7 @@ function createOverviewMap(dataset) {
   });
   view.infobox = function(record) {
     var html = '';
-    html += '<a href="/catalog/' + record.attributes['id'] + '">' + record.attributes['title'] + '</a>';
+    html += '<a href="/portal/' + record.attributes['id'] + '">' + record.attributes['title'] + '</a>';
     html += '<p>' + record.attributes['description_html'] + '</p>';
     html += '<p><strong>URL:</strong> <a href="'+ record.attributes['url'] + '">' + record.attributes['url'] + '</a></p>';
     return html;

--- a/views/_snippets.html
+++ b/views/_snippets.html
@@ -4,7 +4,7 @@
       'http://assets.okfn.org/p/opendatahandbook/img/data-wrench.png'}}"
       alt="{{catalog.title}}" class="logo" />
     <h3><a href="/catalog/{{catalog.id}}">{{catalog.title}}</a></h3>
-    <div class="description">{{catalog.description_html}}</div>
+    <div class="description">{{catalog.description_html|safe}}</div>
     <ul class="keywords">
       {% for kw in catalog.tags or [] %}
         {% if kw %}

--- a/views/_snippets.html
+++ b/views/_snippets.html
@@ -3,7 +3,7 @@
     <img src="{{catalog.image or
       'http://assets.okfn.org/p/opendatahandbook/img/data-wrench.png'}}"
       alt="{{catalog.title}}" class="logo" />
-    <h3><a href="/catalog/{{catalog.id}}">{{catalog.title}}</a></h3>
+    <h3><a href="/portal/{{catalog.id}}">{{catalog.title}}</a></h3>
     <div class="description">{{catalog.description_html|safe}}</div>
     <ul class="keywords">
       {% for kw in catalog.tags or [] %}

--- a/views/catalog.html
+++ b/views/catalog.html
@@ -12,7 +12,7 @@
   <div class="row">
         <div class="col-md-4">
             <h2 style="margin-top: 0">Description</h2>
-            <p>{{ catalog.description }}</p>
+            <p>{{ catalog.description_html|safe }}</p>
             <br>
         </div>
 


### PR DESCRIPTION
In the search view, the HTML was escaped.
In the catalog view, unrendered markdown was shown.

**note**: I did not check if there is a need to protect against XSS attacks, which could be viable now that untrusted (?) HTML is rendered!

edit: also avoid redirects, and add a `npm start` script