### PR TITLE
fix #236: migrate to frictionless repository

### DIFF
--- a/.github/frictionless.yaml
+++ b/.github/frictionless.yaml
@@ -1,0 +1,3 @@
+main:
+  tasks:
+    - path: data/datapackage.json

--- a/.github/workflow/frictionless.yaml
+++ b/.github/workflow/frictionless.yaml
@@ -1,0 +1,18 @@
+name: frictionless
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Validate data
+        uses: frictionlessdata/repository@v1

--- a/data/README.md
+++ b/data/README.md
@@ -1,4 +1,4 @@
-[![goodtables.io](https://goodtables.io/badge/github/okfn/dataportals.org.svg)](https://goodtables.io/github/okfn/dataportals.org)
+[![Data](https://github.com/okfn/dataportals.org/actions/workflows/data.yaml/badge.svg)](https://repository.frictionlessdata.io/report?user=okfn&repo=dataportals.org&flow=data)
 
 Comprehensive list of Open Data Portals around the world. The list is
 maintained by Open Knowledge with the input of the open data community and

--- a/goodtables.yml
+++ b/goodtables.yml
@@ -1,3 +1,0 @@
-datapackages:
-  - 'data/datapackage.json'
-


### PR DESCRIPTION
Is this the correct way to migrate from Goodtables.io to Frictionless Repository, @sapetti9 @roll ?