### PR TITLE
Fix the data package validation

### DIFF
--- a/.github/frictionless.yaml
+++ b/.github/frictionless.yaml
@@ -1,3 +1,4 @@
 main:
   tasks:
-    - path: data/datapackage.json
+    - source: data/datapackage.json
+      type: package


### PR DESCRIPTION
The `path` property is for CSV files which we need to document much better (or improve the API/naming)