### PR TITLE
Fix frictionless data validation badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 Code for running DataPortals.org.
 
+[![Data](https://github.com/okfn/dataportals.org/actions/workflows/frictionless.yaml/badge.svg)](https://repository.frictionlessdata.io/report?user=okfn&repo=dataportals.org&flow=portals)
+
 [The original plans for DataCatalogs.org - Feb 2013](https://docs.google.com/a/okfn.org/document/d/1MP1eaxUPir9msLt4rRwYqdupE3-qeLZAqFXRiXuvwkA/edit).
 Other ideas may be listed as Issues in this repository.
 Conversations with the Open Knowledge community are held in the

--- a/data/README.md
+++ b/data/README.md
@@ -1,4 +1,4 @@
-[![Data](https://github.com/okfn/dataportals.org/actions/workflows/data.yaml/badge.svg)](https://repository.frictionlessdata.io/report?user=okfn&repo=dataportals.org&flow=portals)
+[![Data](https://github.com/okfn/dataportals.org/actions/workflows/frictionless.yaml/badge.svg)](https://repository.frictionlessdata.io/report?user=okfn&repo=dataportals.org&flow=portals)
 
 Comprehensive list of Open Data Portals around the world. The list is
 maintained by Open Knowledge with the input of the open data community and


### PR DESCRIPTION
The badge currently points to a broken url.

This PR fixes #243 and adds the badge to the main README.