### PR TITLE
Add support for running the application in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# DESCRIPTION: dataportals.org website
+# BUILD: docker build --rm -t dataportals .
+# 
+# If you want to build the portal locally in development mode, do:
+#   docker build --rm -t dataportals . --build-arg NODE_ENV=development
+# to build the container, then run
+#   docker run --rm --name dataportals -p 5000:5000 -it dataportals node index.js
+# open http://localhost:5000 on your browser to see the portal.
+
+FROM node:12
+
+ARG NODE_ENV=production
+
+# Never prompt the user for choices on installation/configuration of packages
+ENV DEBIAN_FRONTEND noninteractive
+ENV TERM linux
+ENV NODE_ENV=$NODE_ENV
+# from https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#global-npm-dependencies
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+ENV PATH=$PATH:/home/node/.npm-global/bin
+
+# use non-priviledged user provided by node's docker image
+USER node
+
+# install dependencies
+RUN mkdir -p /home/node/portal
+COPY ./package.json /home/node/portal/package.json
+WORKDIR /home/node/portal
+RUN npm install .
+
+# copy website resources
+COPY ./lib /home/node/portal/lib
+COPY ./routes /home/node/portal/routes
+COPY ./views /home/node/portal/views
+COPY ./public /home/node/portal/public
+COPY ./data /home/node/portal/data
+COPY ./tests /home/node/portal/tests
+COPY ./app.js /home/node/portal/
+
+# port Docusaurus runs on
+EXPOSE 5000

--- a/README.md
+++ b/README.md
@@ -49,14 +49,39 @@ This app requires NodeJS (>= v9.11).
         npm install .
     ```
 
+    Alternatively, you can use Docker to run the application. In that
+    case, build the container instead:
+
+    ```bash
+    docker build --rm -t dataportals .
+    ```
+
+    If you are building a development environment, please use:
+
+    ```bash
+    docker build --rm -t dataportals . --build-arg NODE_ENV=development
+    ```
+
+    so that you can get debugging information.
+
 3. Try it out locally:
 
     ```bash
         node app.js
     ```
 
+    Or, if you're using Docker, start the container instead:
+
+    ```bash
+    docker run --rm --name dataportals -p 5000:5000 -it dataportals node app.js
+    ```
+
    Then point your browser at http://localhost:5000/
 
+   > Note: ctrl+c does not stop the application. You'll have to open another
+   > terminal, run `docker ps` to find out the container id. Then use
+   > `docker stop [container_id]`, replacing what's inside the brackets
+   > with the proper container id.
 
 #### Deployment
 


### PR DESCRIPTION
Running the application in a Docker container will make it easier to develop without needing to set up a node.js developing environment beforehand. It will also make it possible to deploy it in various hosting providers.

Fixes #272