### PR TITLE
Migrate from Frictionless Repository to Frictionless-CI

### DIFF
--- a/.github/frictionless.yaml
+++ b/.github/frictionless.yaml
@@ -1,4 +1,0 @@
-main:
-  tasks:
-    - source: data/datapackage.json
-      type: package

--- a/.github/workflows/frictionless.yaml
+++ b/.github/workflows/frictionless.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - issue-323
   pull_request:
     branches:
       - master

--- a/.github/workflows/frictionless.yaml
+++ b/.github/workflows/frictionless.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - issue-323
   pull_request:
     branches:
       - master
@@ -15,4 +16,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Validate data
-        uses: frictionlessdata/repository@v1
+        uses: frictionlessdata/frictionless-ci@v2
+        with:
+          inquiry: data/data-validation.yaml

--- a/.github/workflows/frictionless.yaml
+++ b/.github/workflows/frictionless.yaml
@@ -18,4 +18,4 @@ jobs:
       - name: Validate data
         uses: frictionlessdata/frictionless-ci@v2
         with:
-          inquiry: data/data-validation.yaml
+          packages: data/datapackage.json

--- a/data/data-validation.yaml
+++ b/data/data-validation.yaml
@@ -1,0 +1,2 @@
+tasks:
+  - source: data/datapackage.json

--- a/data/data-validation.yaml
+++ b/data/data-validation.yaml
@@ -1,2 +1,0 @@
-tasks:
-  - source: data/datapackage.json


### PR DESCRIPTION
This PR will migrate Github Actions data validation from using Frictionless Repository to the newer Frictionless-CI.

Fixes #323.